### PR TITLE
Center news cards

### DIFF
--- a/partials/sections/news.html
+++ b/partials/sections/news.html
@@ -2,8 +2,8 @@
     <div class="max-w-6xl mx-auto px-6">
         <h2 class="text-4xl md:text-5xl lg:text-6xl font-bold text-center mb-20 tracking-tight">News</h2>
 
-        <!-- News cards grid - responsive from 1 to 3 columns -->
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
+        <!-- News cards grid - keep two columns and center them -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-10 max-w-3xl mx-auto">
             <!-- News Card 1: Technology Update -->
             <div
                 class="bg-white rounded-2xl shadow-md overflow-hidden border-t-4 border-blue-500 transition-transform duration-500 hover:-translate-y-1 hover:shadow-2xl">


### PR DESCRIPTION
## Summary
- adjust news cards grid width
- keep two columns at large widths for better centering

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686392ceffac832da543a0002acb1c8b